### PR TITLE
Implement encoding support according to WHATWG spec

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "form_coder"
-version = "0.1.0"
+version = "0.2.0"
 
 licences = ["Apache-2.0"]
 description = "A Gleam library for encoding and decoding `x-www-form-urlencoded` data"

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ description = "A Gleam library for encoding and decoding `x-www-form-urlencoded`
 repository = { type = "github", user = "J3RN", repo = "form_coder" }
 
 [dependencies]
-gleam_stdlib = "~> 0.18"
+gleam_stdlib = "~> 0.26"
 
 [dev-dependencies]
-gleeunit = "~> 0.6"
+gleeunit = "~> 0.10"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.19.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "FFA79EA12369F122B68885E694E097D6810402A2F86BFF48AAE9E40ACE654F4C" },
-  { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
+  { name = "gleam_stdlib", version = "0.26.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6221F9D7A08B6D6DBCDD567B2BB7C4B2A7BBF4C04C6110757BE04635143BDEC8" },
+  { name = "gleeunit", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "59E8B9B26BF732500C0F52C76DBA293480EA9E1E213FD9196BDE2A290E08C427" },
 ]
 
 [requirements]
-gleam_stdlib = "~> 0.18"
-gleeunit = "~> 0.6"
+gleam_stdlib = "~> 0.26"
+gleeunit = "~> 0.10"

--- a/src/form_coder.gleam
+++ b/src/form_coder.gleam
@@ -1,9 +1,17 @@
-import gleam/dynamic.{Dynamic}
+//// x-www-form-urlencoded codec
+////
+//// The codec follows the WHATWG specification available at:
+//// https://url.spec.whatwg.org/#application/x-www-form-urlencoded but uses
+//// UTF-8 as the only supported encoding.
+
+import gleam/dynamic
 import gleam/list
 import gleam/map.{Map}
 import gleam/uri
 import gleam/result
 import gleam/string
+import gleam/string_builder
+import gleam/option
 
 pub type Query {
   QStr(String)
@@ -11,20 +19,31 @@ pub type Query {
   QMap(Map(String, Query))
 }
 
+/// Characters not encoded by Gleam's percent encoding, but that we need to encode
+const not_encoded_by_gleam = [
+  #("!", "%21"),
+  #("$", "%24"),
+  #("'", "%27"),
+  #("(", "%28"),
+  #(")", "%29"),
+  #("+", "%2B"),
+  #("~", "%7E"),
+]
+
 /// Encode a list of pairs into a URL query string
 ///
 /// The values of these pairs should be of the `Query` type.
 ///
 /// ## Examples
 ///
-///    > encode([#("foo", QStr("bar")), #("baz", QStr("qux"))])
-///    "foo=bar&baz=qux"
+///    > encode([#("foo", QStr("bar bar")), #("baz", QStr("qux"))])
+///    "foo=bar+bar&baz=qux"
 ///
-///    > encode([#("foo", QList([QStr("bar"), QStr("baz")]))])
-///    "foo[]=bar&foo[]=baz"
+///    > encode([#("foo", QList([QStr("bar"), QStr("b!z")]))])
+///    "foo%5B%5D=bar&foo%5B%5D=b%21z"
 ///
 ///    > encode([#("foo", QMap(map.from_list([#("bar", "baz")])))])
-///    "foo[bar]=baz"
+///    "foo%5Bbar%5D=baz"
 ///
 pub fn encode(contents: List(#(String, Query))) -> String {
   contents
@@ -32,19 +51,36 @@ pub fn encode(contents: List(#(String, Query))) -> String {
     let #(key, value) = pair
     encode_query(key, value)
   })
-  |> string.join(with: "&")
+  |> string_builder.join(with: "&")
+  |> string_builder.to_string()
 }
 
 fn encode_query(key, query) {
   case query {
-    QStr(str) -> encode_string(key, str)
+    QStr(str) -> encode_string(key, str, option.None)
     QList(values) -> encode_list(key, values)
     QMap(pairs) -> encode_map(key, pairs)
   }
 }
 
-fn encode_string(key, str) {
-  [string.concat([key, "=", str])]
+fn encode_string(key, str, collection_key: option.Option(String)) {
+  let key = string_builder.from_string(key)
+  let str = string_builder.from_string(str)
+
+  let key = case collection_key {
+    option.Some(collection_key) ->
+      key
+      |> string_builder.append("[")
+      |> string_builder.append(collection_key)
+      |> string_builder.append("]")
+    option.None -> key
+  }
+
+  [
+    encode_term(key)
+    |> string_builder.append("=")
+    |> string_builder.append_builder(encode_term(str)),
+  ]
 }
 
 fn encode_list(key, values) {
@@ -60,6 +96,25 @@ fn encode_map(key, pairs) {
   })
 }
 
+fn encode_term(term: string_builder.StringBuilder) {
+  term
+  |> string_builder.split(" ")
+  |> list.map(fn(part) {
+    let encoded = uri.percent_encode(string_builder.to_string(part))
+
+    list.fold(
+      not_encoded_by_gleam,
+      encoded,
+      fn(acc, item) {
+        let #(char, replacement) = item
+        string.replace(acc, char, replacement)
+      },
+    )
+    |> string_builder.from_string()
+  })
+  |> string_builder.join("+")
+}
+
 pub type DecodeError {
   InvalidQuery
   DynamicError(List(dynamic.DecodeError))
@@ -69,7 +124,7 @@ pub type DecodeError {
 /// (likely a function from `gleam/dynamic`).
 pub fn decode(
   from encoded: String,
-  using decoder: fn(Dynamic) -> Result(a, List(dynamic.DecodeError)),
+  using decoder: dynamic.Decoder(a),
 ) -> Result(a, DecodeError) {
   encoded
   |> string.split("&")
@@ -92,6 +147,9 @@ fn decode_pair(pair) {
   try #(key, value) = string.split_once(pair, "=")
   try key = uri.percent_decode(key)
   try value = uri.percent_decode(value)
+
+  let key = string.replace(key, "+", " ")
+  let value = string.replace(value, "+", " ")
   Ok(#(key, value))
 }
 

--- a/src/form_coder.gleam
+++ b/src/form_coder.gleam
@@ -11,7 +11,6 @@ import gleam/uri
 import gleam/result
 import gleam/string
 import gleam/string_builder
-import gleam/option
 
 pub type Query {
   QStr(String)
@@ -57,24 +56,15 @@ pub fn encode(contents: List(#(String, Query))) -> String {
 
 fn encode_query(key, query) {
   case query {
-    QStr(str) -> encode_string(key, str, option.None)
+    QStr(str) -> encode_string(key, str)
     QList(values) -> encode_list(key, values)
     QMap(pairs) -> encode_map(key, pairs)
   }
 }
 
-fn encode_string(key, str, collection_key: option.Option(String)) {
+fn encode_string(key, str) {
   let key = string_builder.from_string(key)
   let str = string_builder.from_string(str)
-
-  let key = case collection_key {
-    option.Some(collection_key) ->
-      key
-      |> string_builder.append("[")
-      |> string_builder.append(collection_key)
-      |> string_builder.append("]")
-    option.None -> key
-  }
 
   [
     encode_term(key)

--- a/test/form_coder_test.gleam
+++ b/test/form_coder_test.gleam
@@ -1,5 +1,4 @@
 import gleeunit
-import gleeunit/should
 import gleam/map
 import gleam/dynamic
 import form_coder.{QList, QMap, QStr}

--- a/test/form_coder_test.gleam
+++ b/test/form_coder_test.gleam
@@ -1,4 +1,5 @@
 import gleeunit
+import gleeunit/should
 import gleam/map
 import gleam/dynamic
 import form_coder.{QList, QMap, QStr}
@@ -11,7 +12,7 @@ pub fn main() {
 pub fn encode_strings_test() {
   let data = [#("foo", QStr("bar")), #("baz", QStr("qux"))]
 
-  assert "foo=bar&baz=qux" = form_coder.encode(data)
+  should.equal(form_coder.encode(data), "foo=bar&baz=qux")
 }
 
 pub fn encode_lists_test() {
@@ -20,8 +21,10 @@ pub fn encode_lists_test() {
     #("product_ids", QList([QStr("5"), QStr("7")])),
   ]
 
-  assert "user_ids[]=1&user_ids[]=2&product_ids[]=5&product_ids[]=7" =
-    form_coder.encode(data)
+  should.equal(
+    form_coder.encode(data),
+    "user_ids%5B%5D=1&user_ids%5B%5D=2&product_ids%5B%5D=5&product_ids%5B%5D=7",
+  )
 }
 
 pub fn encode_maps_test() {
@@ -36,8 +39,10 @@ pub fn encode_maps_test() {
     ),
   ]
 
-  assert "person[age]=71&person[name]=Joe&cat[age]=5&cat[name]=Nubi" =
-    form_coder.encode(data)
+  should.equal(
+    form_coder.encode(data),
+    "person%5Bage%5D=71&person%5Bname%5D=Joe&cat%5Bage%5D=5&cat%5Bname%5D=Nubi",
+  )
 }
 
 pub fn encode_mixed_nonsense_test() {
@@ -50,8 +55,10 @@ pub fn encode_mixed_nonsense_test() {
     #("foo", QStr("bar")),
   ]
 
-  assert "person[age]=71&person[name]=Joe&user_ids[]=1&user_ids[]=2&foo=bar" =
-    form_coder.encode(data)
+  should.equal(
+    form_coder.encode(data),
+    "person%5Bage%5D=71&person%5Bname%5D=Joe&user_ids%5B%5D=1&user_ids%5B%5D=2&foo=bar",
+  )
 }
 
 pub fn encode_nested_nonsense_test() {
@@ -75,17 +82,66 @@ pub fn encode_nested_nonsense_test() {
     ),
   ]
 
-  assert "products[][name]=Toaster&products[][price]=15&products[][name]=Microwave&products[][price]=50&people[count]=3&people[names][]=Joe&people[names][]=Robert&people[names][]=Mike" =
-    form_coder.encode(data)
+  should.equal(
+    form_coder.encode(data),
+    "products%5B%5D%5Bname%5D=Toaster&products%5B%5D%5Bprice%5D=15&products%5B%5D%5Bname%5D=Microwave&products%5B%5D%5Bprice%5D=50&people%5Bcount%5D=3&people%5Bnames%5D%5B%5D=Joe&people%5Bnames%5D%5B%5D=Robert&people%5Bnames%5D%5B%5D=Mike",
+  )
+}
+
+pub fn encode_spaces_test() {
+  let data = [#("can I have some spaces", QStr("please enjoy these spaces"))]
+
+  should.equal(
+    form_coder.encode(data),
+    "can+I+have+some+spaces=please+enjoy+these+spaces",
+  )
+}
+
+pub fn encode_chars_test() {
+  let data = [#("äöå", QStr("!$'()+~"))]
+
+  should.equal(
+    form_coder.encode(data),
+    "%C3%A4%C3%B6%C3%A5=%21%24%27%28%29%2B%7E",
+  )
+}
+
+pub fn keep_chars_test() {
+  let data = [#("ok_chars", QStr("_-*."))]
+
+  should.equal(form_coder.encode(data), "ok_chars=_-*.")
 }
 
 // Decoding
 pub fn decode_strings_test() {
   let query = "foo=bar&baz=qux"
 
-  assert Ok([#("foo", "bar"), #("baz", "qux")]) =
-    form_coder.decode(
-      query,
-      dynamic.list(of: dynamic.tuple2(dynamic.string, dynamic.string)),
-    )
+  form_coder.decode(
+    query,
+    dynamic.list(of: dynamic.tuple2(dynamic.string, dynamic.string)),
+  )
+  |> should.be_ok()
+  |> should.equal([#("foo", "bar"), #("baz", "qux")])
+}
+
+pub fn decode_spaces_test() {
+  let query = "foo+space=bar+bar"
+
+  form_coder.decode(
+    query,
+    dynamic.list(of: dynamic.tuple2(dynamic.string, dynamic.string)),
+  )
+  |> should.be_ok()
+  |> should.equal([#("foo space", "bar bar")])
+}
+
+pub fn decode_chars_test() {
+  let query = "*%C3%B6ljy*=%C3%A5ngstr%C3%B6m%21"
+
+  form_coder.decode(
+    query,
+    dynamic.list(of: dynamic.tuple2(dynamic.string, dynamic.string)),
+  )
+  |> should.be_ok()
+  |> should.equal([#("*öljy*", "ångström!")])
 }


### PR DESCRIPTION
Currently the library does not do encoding according to the [WHATWG spec](https://url.spec.whatwg.org/#application/x-www-form-urlencoded). In fact there is no encoding of keys and values at all, so keys and values must already be properly formatted.

This PR implements proper encoding and decoding. Spaces are encoded/decoded as `+`, all other characters except `_-.*` are percent encoded. I used `string_builder` to avoid concatenating lots of strings when encoding.

Let me know what you think. :)